### PR TITLE
Extract tags from headers

### DIFF
--- a/src/lf_asv_formatter/simple_formatter.py
+++ b/src/lf_asv_formatter/simple_formatter.py
@@ -85,7 +85,7 @@ class SimpleFormatter(AsvFormatter):
         content = ""
         if len(tags) == 2:
             # Add message about version comparison
-            content += f"Comparing <{tags[0]}> and <{tags[1]}>\n\n"
+            content += f"Comparing **<{tags[0]}>** and **<{tags[1]}>**\n\n"
         content += f"|{'|'.join(headers)}|\n"
         # +1 to account for the header separator
         max_row = min(self.MAX_NUM_ROWS, len(bench_data)) + 1
@@ -137,7 +137,7 @@ class SimpleFormatter(AsvFormatter):
             match = re.search(tag_pattern, header)
             if match:
                 tag = match.group(1)
-                tags.append(tag)
+                tags.append(re.escape(tag))
                 # Erase tag from the header
                 padding = " " * (len(tag) + 2)
                 new_header = re.sub(tag_pattern, padding, header)

--- a/tests/data/simple/expected_output_verbose
+++ b/tests/data/simple/expected_output_verbose
@@ -1,4 +1,4 @@
-Comparing <add-docs~15> and <upgrade-asv>
+Comparing **<add\-docs\~15>** and **<upgrade\-asv>**
 
 | Before [a4e3082d]                 | After [8110f9f7]                 | Ratio   | Benchmark (Parameter)              |
 |-----------------------------------|----------------------------------|---------|------------------------------------|

--- a/tests/data/simple/expected_output_verbose
+++ b/tests/data/simple/expected_output_verbose
@@ -1,4 +1,6 @@
-| Before [a4e3082d] <add-docs~15>   | After [8110f9f7] <upgrade-asv>   | Ratio   | Benchmark (Parameter)              |
+Comparing <add-docs~15> and <upgrade-asv>
+
+| Before [a4e3082d]                 | After [8110f9f7]                 | Ratio   | Benchmark (Parameter)              |
 |-----------------------------------|----------------------------------|---------|------------------------------------|
 | 692±600ms                         | 2.72±1s                          | ~3.93   | benchmarks.TimeSuite.time_iterkeys |
 | 867±400ms                         | 2.21±1s                          | ~2.55   | benchmarks.TimeSuite.time_range    |

--- a/tests/data/simple/expected_output_with_tags
+++ b/tests/data/simple/expected_output_with_tags
@@ -1,0 +1,9 @@
+Comparing <0.0.1~59> and <new-branch>
+
+| Before [a4e3082d]              | After [6f9dea7d]                | Ratio   | Benchmark (Parameter)              |
+|--------------------------------|---------------------------------|---------|------------------------------------|
+| 724±600ms                      | 1.83±0.4s                       | ~2.53   | benchmarks.TimeSuite.time_range    |
+| 671±300ms                      | 1.55±0.7s                       | ~2.30   | benchmarks.TimeSuite.time_keys     |
+| 1.25±0.3s                      | 2.35±1s                         | ~1.88   | benchmarks.TimeSuite.time_xrange   |
+| 1.26±0.4s                      | 1.15±0.8s                       | 0.91    | benchmarks.TimeSuite.time_iterkeys |
+| 5.98k                          | 3.1k                            | 0.52    | benchmarks.MemSuite.mem_list       |

--- a/tests/data/simple/expected_output_with_tags
+++ b/tests/data/simple/expected_output_with_tags
@@ -1,4 +1,4 @@
-Comparing <0.0.1~59> and <new-branch>
+Comparing **<0\.0\.1\~59>** and **<new\-branch>**
 
 | Before [a4e3082d]              | After [6f9dea7d]                | Ratio   | Benchmark (Parameter)              |
 |--------------------------------|---------------------------------|---------|------------------------------------|

--- a/tests/data/simple/original_output_with_tags
+++ b/tests/data/simple/original_output_with_tags
@@ -1,0 +1,10 @@
+
+All benchmarks:
+
+| Change   | Before [a4e3082d] <0.0.1~59>   | After [6f9dea7d] <new-branch>   | Ratio   | Benchmark (Parameter)              |
+|----------|--------------------------------|---------------------------------|---------|------------------------------------|
+|          | 724±600ms                      | 1.83±0.4s                       | ~2.53   | benchmarks.TimeSuite.time_range    |
+|          | 671±300ms                      | 1.55±0.7s                       | ~2.30   | benchmarks.TimeSuite.time_keys     |
+|          | 1.25±0.3s                      | 2.35±1s                         | ~1.88   | benchmarks.TimeSuite.time_xrange   |
+|          | 1.26±0.4s                      | 1.15±0.8s                       | 0.91    | benchmarks.TimeSuite.time_iterkeys |
+| -        | 5.98k                          | 3.1k                            | 0.52    | benchmarks.MemSuite.mem_list       |

--- a/tests/lf_asv_formatter/test_asv_formatter.py
+++ b/tests/lf_asv_formatter/test_asv_formatter.py
@@ -36,7 +36,7 @@ def test_rewrite_file_simple(assert_text_file_matches, tmp_path, test_data_simpl
 
 
 def test_rewrite_file_tabulate(
-    assert_text_file_matches, tmp_path, test_data_tabulate_dir
+        assert_text_file_matches, tmp_path, test_data_tabulate_dir
 ):
     """Confirm that we write out the file with the expected GitHub formatting using tabulate."""
     (
@@ -52,3 +52,12 @@ def test_rewrite_file_tabulate(
     # If the output is verbose
     TabulateFormatter(original_output_verbose, output_file).rewrite_file()
     assert_text_file_matches(output_file, expected_output_verbose)
+
+
+def test_simple_formatter_with_tags(assert_text_file_matches, test_data_simple_dir, tmp_path):
+    """Confirms that we can write out the expected table, extracting the branch / version tags"""
+    original_output_with_tags = os.path.join(test_data_simple_dir, "original_output_with_tags")
+    expected_output_with_tags = os.path.join(test_data_simple_dir, "expected_output_with_tags")
+    output_file = os.path.join(tmp_path, "output_file")
+    SimpleFormatter(original_output_with_tags, output_file).rewrite_file()
+    assert_text_file_matches(output_file, expected_output_with_tags)


### PR DESCRIPTION
Extracts branch / version tags from the asv table headers and adds a one-liner with the information about the comparison right before the start of the table. More information about the changes can be found in [this](https://github.com/lincc-frameworks/asv-formatter/issues/5#issuecomment-1861806988) issue comment. Closes #5. 